### PR TITLE
Limit visibility of some toots

### DIFF
--- a/bots/autoToot.py
+++ b/bots/autoToot.py
@@ -160,7 +160,7 @@ class AutoToot:
             m = self.api.status_post(text, in_reply_to_id = mid, media_ids = media_ids)
             mid = m.id
 
-        self.api.status_post("Post original :\nhttps://twitter.com/"+tt[0].author.screen_name+"/status/"+str(tt[0].id), in_reply_to_id = mid)
+        self.api.status_post("Post original :\nhttps://twitter.com/"+tt[0].author.screen_name+"/status/"+str(tt[0].id), in_reply_to_id = mid, visibility = "unlisted")
 
     def postTagThreads(self, threads):
         for tt in threads:


### PR DESCRIPTION
Hello,

Avec cette petite modification, les messages « Post original » s'afficheront toujours bien à toute personne qui cliquera sur l'un des messages du thread, mais sans apparaitre dans la timeline locale ou la timeline fédérée par défaut.

Cela devrait limiter un peu le nombre de messages postés en « batch », et améliorer la lisibilité de la timeline locale de sciences.re !
 
cc @juliengossa 
